### PR TITLE
Revamp webOS with Windows 11 features and apps

### DIFF
--- a/apps/browser.html
+++ b/apps/browser.html
@@ -5,6 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>WebOS Browser</title>
   <link rel="stylesheet" href="browser.css" />
+  <!-- Ultraviolet Proxy Scripts -->
+  <script src="../../src/uv/uv.bundle.js"></script>
+  <script src="../../src/uv/uv.config.js"></script>
+  <script src="../../src/uv/uv.handler.js"></script>
+  <script src="../../src/uv/uv.sw.js"></script>
 </head>
 <body>
   <div class="browser-app">
@@ -16,6 +21,10 @@
       <button id="back-btn" title="Back">⟨</button>
       <button id="forward-btn" title="Forward">⟩</button>
       <button id="reload-btn" title="Reload">⟳</button>
+      <select id="proxy-mode" title="Proxy Mode">
+        <option value="direct">Direct</option>
+        <option value="ultraviolet">Ultraviolet</option>
+      </select>
       <input id="browser-address" type="text" placeholder="Search or enter address" />
       <button id="go-btn">Go</button>
     </div>

--- a/apps/browser.js
+++ b/apps/browser.js
@@ -2,6 +2,7 @@ const tabs = [];
 let activeTab = null;
 let browserTheme = localStorage.getItem('browserTheme') || 'light';
 let bookmarks = JSON.parse(localStorage.getItem('browserBookmarks') || '[]');
+let proxyMode = 'direct';
 
 function setBrowserTheme(theme) {
   document.body.setAttribute('data-browser-theme', theme);
@@ -79,7 +80,19 @@ function renderContent() {
     }, 0);
   } else {
     const iframe = document.createElement('iframe');
-    iframe.src = activeTab.url;
+    if (proxyMode === 'ultraviolet') {
+      // Use Ultraviolet proxy
+      if (window.uv && window.uv.encodeUrl) {
+        const encodedUrl = window.uv.encodeUrl(activeTab.url);
+        iframe.src = encodedUrl;
+      } else {
+        // Fallback to direct if UV not loaded
+        iframe.src = activeTab.url;
+      }
+    } else {
+      // Direct mode
+      iframe.src = activeTab.url;
+    }
     iframe.style = 'width:100%;height:100%;border:none;';
     content.appendChild(iframe);
   }
@@ -145,6 +158,12 @@ document.getElementById('forward-btn').onclick = () => {
 document.getElementById('reload-btn').onclick = () => {
   const iframe = document.querySelector('.browser-content iframe');
   if (iframe) iframe.contentWindow.location.reload();
+};
+document.getElementById('proxy-mode').onchange = function() {
+  proxyMode = this.value;
+  if (activeTab && activeTab.url) {
+    renderContent();
+  }
 };
 
 // Bookmarks bar: right-click to add current tab as bookmark

--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ window.onerror = function(msg, url, line, col, error) {
 };
 
 document.addEventListener('DOMContentLoaded', function() {
+  const timeDisplay = document.getElementById('time-display');
 // --- Draggable Windows ---
 function makeDraggable(win) {
   let isDragging = false, offsetX, offsetY;
@@ -31,7 +32,6 @@ const contextMenu = document.getElementById('context-menu');
 const startMenu = document.getElementById('start-menu');
 const startBtn = document.getElementById('start-btn');
 const taskbarApps = document.getElementById('taskbar-apps');
-const timeDisplay = document.getElementById('time-display');
 let zIndexCounter = 20;
 let openWindows = [];
 


### PR DESCRIPTION
Fix macOS theme popups, window dragging, app launch issues, and update open app indicators.

The macOS theme was causing constant popups due to aggressive update logic. Window dragging was unintentionally applied to app content. Desktop icons were not launching apps due to an event handling issue. The open app indicator was updated from a general taskbar button highlight to a more OS-specific underline (Windows/ChromeOS/Linux) or dot (macOS) under the app icon.